### PR TITLE
initial refactor of TemporalReference and TemporalRegion to make the …

### DIFF
--- a/src/main/java/edu/uams/dbmi/rts/RtsDeclaration.java
+++ b/src/main/java/edu/uams/dbmi/rts/RtsDeclaration.java
@@ -1,5 +1,5 @@
 package edu.uams.dbmi.rts;
 
-public abstract class RtsDeclaration {
+public interface RtsDeclaration {
 
 }

--- a/src/main/java/edu/uams/dbmi/rts/RtsTupleFactory.java
+++ b/src/main/java/edu/uams/dbmi/rts/RtsTupleFactory.java
@@ -295,8 +295,10 @@ public class RtsTupleFactory {
 	private void populatePtoUTuple(PtoUTuple t, List<String> contentFields) {
 		
 		//contentFields.get(1) is ta
-		TemporalReference tr = new TemporalReference(contentFields.get(1), contentFields.get(1).contains("Z"));
-		t.setAuthoringTimeReference(tr);
+		String taId = contentFields.get(1);
+		TemporalReference ta = (taId.endsWith("Z")) ? new TemporalReference(taId, TemporalReference.ISO_IUI) :
+				new TemporalReference(taId, TemporalReference.RTS_TR_IUI);
+		t.setAuthoringTimeReference(ta);
 		
 		//contentFields.get(2) is r
 		if (contentFields.get(2).startsWith("-!-")) {
@@ -320,15 +322,20 @@ public class RtsTupleFactory {
 		t.setUniversalOntologyIui(Iui.createFromString(contentFields.get(6)));
 		
 		//contentFields.get(7) is tr
-		t.setTemporalReference(new TemporalReference(contentFields.get(7), contentFields.get(7).contains("Z")));
+		String trId = contentFields.get(7);
+		TemporalReference tr = (trId.endsWith("Z")) ? new TemporalReference(trId, TemporalReference.ISO_IUI) :
+				new TemporalReference(trId, TemporalReference.RTS_TR_IUI);
+		t.setTemporalReference(tr);
 
 	}
 
 	private void populatePtoPTuple(PtoPTuple t, List<String> contentFields) {
 		
 		//contentFields.get(1) is ta
-		TemporalReference tr = new TemporalReference(contentFields.get(1), contentFields.get(1).contains("Z"));
-		t.setAuthoringTimeReference(tr);
+		String taId = contentFields.get(1);
+		TemporalReference ta = (taId.endsWith("Z")) ? new TemporalReference(taId, TemporalReference.ISO_IUI) :
+				new TemporalReference(taId, TemporalReference.RTS_TR_IUI);
+		t.setAuthoringTimeReference(ta);
 		
 		//contentFields.get(2) is r
 		if (contentFields.get(2).startsWith("-!-")) {
@@ -350,7 +357,8 @@ public class RtsTupleFactory {
 				Iui iui = Iui.createFromString(refInfo[1]);
 				t.addParticular(iui);
 			} else if (refInfo[0].equals("tref")) {
-				TemporalReference tref = new TemporalReference(refInfo[1], refInfo[1].contains("Z"));
+				TemporalReference tref = (refInfo[1].endsWith("Z")) ? new TemporalReference(refInfo[1], TemporalReference.ISO_IUI) : 
+					new TemporalReference(refInfo[1], TemporalReference.RTS_TR_IUI);
 				t.addParticular(tref);
 			} else {
 				throw new IllegalArgumentException("particular reference type must be 'iui' or 'tref'");
@@ -358,15 +366,20 @@ public class RtsTupleFactory {
 		}
 					
 		//contentFields.get(5) is tr
-		t.setTemporalReference(new TemporalReference(contentFields.get(5), contentFields.get(5).contains("Z")));
+		String trId = contentFields.get(5);
+		TemporalReference tr = (trId.endsWith("Z")) ? new TemporalReference(trId, TemporalReference.ISO_IUI) :
+				new TemporalReference(trId, TemporalReference.RTS_TR_IUI);
+		t.setTemporalReference(tr);
 
 	}
 
 	private void populatePtoLackUTuple(PtoLackUTuple t, List<String> contentFields) {
 		
 		//contentFields.get(1) is ta
-		TemporalReference tr = new TemporalReference(contentFields.get(1), contentFields.get(1).contains("Z"));
-		t.setAuthoringTimeReference(tr);
+		String taId = contentFields.get(1);
+		TemporalReference ta = (taId.endsWith("Z")) ? new TemporalReference(taId, TemporalReference.ISO_IUI) :
+				new TemporalReference(taId, TemporalReference.RTS_TR_IUI);
+		t.setAuthoringTimeReference(ta);
 		
 		//contentFields.get(2) is r
 		t.setRelationshipURI(URI.create(contentFields.get(2)));
@@ -384,15 +397,20 @@ public class RtsTupleFactory {
 		t.setUniversalOntologyIui(Iui.createFromString(contentFields.get(6)));
 		
 		//contentFields.get(7) is tr
-		t.setTemporalReference(new TemporalReference(contentFields.get(7), contentFields.get(7).contains("Z")));
+		String trId = contentFields.get(7);
+		TemporalReference tr = (trId.endsWith("Z")) ? new TemporalReference(trId, TemporalReference.ISO_IUI) :
+				new TemporalReference(trId, TemporalReference.RTS_TR_IUI);
+		t.setTemporalReference(tr);
 		
 	}
 
 	private void populatePtoCTuple(PtoCTuple t, List<String> contentFields) {
 		
 		//contentFields.get(1) is ta
-		TemporalReference tr = new TemporalReference(contentFields.get(1), contentFields.get(1).contains("Z"));
-		t.setAuthoringTimeReference(tr);
+		String taId = contentFields.get(1);
+		TemporalReference ta = (taId.endsWith("Z")) ? new TemporalReference(taId, TemporalReference.ISO_IUI) :
+				new TemporalReference(taId, TemporalReference.RTS_TR_IUI);
+		t.setAuthoringTimeReference(ta);
 		
 		//contentFields.get(2) is IUIc
 		t.setConceptSystemIui(Iui.createFromString(contentFields.get(2)));
@@ -404,14 +422,19 @@ public class RtsTupleFactory {
 		t.setConceptCui(new Cui(contentFields.get(4)));
 		
 		//contentFields.get(5) is tr
-		t.setTemporalReference(new TemporalReference(contentFields.get(5), contentFields.get(5).contains("Z")));
+		String trId = contentFields.get(5);
+		TemporalReference tr = (trId.endsWith("Z")) ? new TemporalReference(trId, TemporalReference.ISO_IUI) :
+				new TemporalReference(trId, TemporalReference.RTS_TR_IUI);
+		t.setTemporalReference(tr);
 	}
 
 	private void populatePtoDETuple(PtoDETuple t, List<String> contentFields) {
 		
 		//contentFields.get(1) is ta
-		TemporalReference tr = new TemporalReference(contentFields.get(1), contentFields.get(1).contains("Z"));
-		t.setAuthoringTimeReference(tr);
+		String taId = contentFields.get(1);
+		TemporalReference ta = (taId.endsWith("Z")) ? new TemporalReference(taId, TemporalReference.ISO_IUI) :
+				new TemporalReference(taId, TemporalReference.RTS_TR_IUI);
+		t.setAuthoringTimeReference(ta);
 		
 		//contentFields.get(2) is r
 		t.setRelationshipURI(URI.create(contentFields.get(2)));
@@ -425,7 +448,8 @@ public class RtsTupleFactory {
 			Iui iui = Iui.createFromString(refInfo[1]);
 			t.setReferent(iui);
 		} else if (refInfo[0].equals("tref")) {
-			TemporalReference tref = new TemporalReference(refInfo[1], refInfo[1].contains("Z"));
+				TemporalReference tref = (refInfo[1].endsWith("Z")) ? new TemporalReference(refInfo[1], TemporalReference.ISO_IUI) : 
+					new TemporalReference(refInfo[1], TemporalReference.RTS_TR_IUI);
 			t.setReferent(tref);
 		} else {
 			throw new IllegalArgumentException("particular reference type must be 'iui' or 'tref'");
@@ -505,13 +529,12 @@ public class RtsTupleFactory {
 		
 		// 0 - first thing in content fields is the temporal reference for the region
 		String tRefTxt = contentFields.get(0);
-		TemporalReference tref = new TemporalReference(tRefTxt, nsIui.equals(TemporalRegion.ISO_IUI));
 		
 		// 1 - next thing in content fields is UUI -- almost always will BFO IRI -- for type of region
 		String typeTxt = contentFields.get(1);
 		Uui typeUui = new Uui(typeTxt);
 				
-		return new TemporalRegion(tref, typeUui, nsIui);
+		return new TemporalRegion(tRefTxt, nsIui, typeUui);
 	}
 
 }

--- a/src/main/java/edu/uams/dbmi/rts/time/TemporalReference.java
+++ b/src/main/java/edu/uams/dbmi/rts/time/TemporalReference.java
@@ -1,21 +1,48 @@
 package edu.uams.dbmi.rts.time;
 
+import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
+import edu.uams.dbmi.rts.iui.Iui;
 import edu.uams.dbmi.rts.ParticularReference;
+import edu.uams.dbmi.rts.RtsDeclaration;
 import edu.uams.dbmi.util.iso8601.Iso8601Date;
 import edu.uams.dbmi.util.iso8601.Iso8601DateFormatter;
 import edu.uams.dbmi.util.iso8601.Iso8601TimeZoneFormatter;
 import edu.uams.dbmi.util.iso8601.Iso8601Date.DateConfiguration;
+import edu.uams.dbmi.util.iso8601.Iso8601DateTime;
+import edu.uams.dbmi.util.iso8601.Iso8601DateTimeFormatter;
+import edu.uams.dbmi.util.iso8601.Iso8601Time;
+import edu.uams.dbmi.util.iso8601.Iso8601UnitTime;
+import edu.uams.dbmi.util.iso8601.TimeUnit;
 
-public class TemporalReference extends ParticularReference {
+public class TemporalReference extends ParticularReference implements RtsDeclaration {
 	String identifier;
-	boolean isIso;
+	Iui calendarSystemIui;
+
+	public static final Iui ISO_IUI;
+	public static final Iui RTS_TR_IUI;
 	
-	public TemporalReference(String identifier, boolean isIso) {
+	static {
+		ISO_IUI = Iui.createFromString("D4AF5C9A-47BA-4BF4-9BAE-F13A8ED6455E");
+		RTS_TR_IUI =  Iui.createFromString("DB2282A4-631F-4D2C-940F-A220C496F6BE");
+	}
+	
+	public TemporalReference(String identifier, Iui calendarSystemIui) {
 		this.identifier = identifier;
-		this.isIso = isIso;
+		setCalendarSystemIui(calendarSystemIui);
+	}
+
+	protected void setCalendarSystemIui(Iui calendarSystemIui) {
+		if (calendarSystemIui == null) {
+			throw new IllegalArgumentException("calendar system IUI cannot be null: " + calendarSystemIui);
+		}
+		this.calendarSystemIui = calendarSystemIui;
+		if (!this.calendarSystemIui.equals(ISO_IUI) && !this.calendarSystemIui.equals(RTS_TR_IUI)) {
+			System.out.println("WARNING: Calendar system iui is neither the standard for ISO date/time strings" +
+				" nor the standard for RT systems themselves.");
+		}
 	}
 	
 	/**
@@ -50,8 +77,33 @@ public class TemporalReference extends ParticularReference {
 			//for dates, we use underscore for easy splitting off of time zone info later
 			identifier = df.format(date) + "_Z";
 		}
-		isIso = true;
+		this.calendarSystemIui = ISO_IUI;	
+	}
+
+	public TemporalReference(Iso8601DateTime dateTime) {
+		//regardless of whether time zone is specified, when we ask
+		//  the date/time object for a Calendar object, it comes 
+		//  with one (if not specified, it's the local one).
+		Calendar c = dateTime.getCalendar();
+		GregorianCalendar cZ = (GregorianCalendar)Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+		cZ.setTimeInMillis(c.getTimeInMillis());
+		//building from Calendar ensures we get a time zone
+		Iso8601DateTime dtZ = new Iso8601DateTime(cZ);
+		Iso8601DateTimeFormatter dtf = new Iso8601DateTimeFormatter();
 		
+		this.identifier = dtf.format(dtZ);
+		this.calendarSystemIui = ISO_IUI;
+	}
+
+	public TemporalReference(Iso8601DateTime dateTime, TimeZone tz) {
+		GregorianCalendar c = (GregorianCalendar)dateTime.getCalendar(); 
+		//opposite of offset because we're converting from local to UTC, not 
+		// the other way around (offset is what you do to UTC to get local).
+		c.add(Calendar.MILLISECOND, -tz.getOffset(c.getTimeInMillis()));
+		Iso8601DateTime txDt = new Iso8601DateTime(c);			
+		Iso8601DateTimeFormatter dtf = new Iso8601DateTimeFormatter();
+		this.identifier = dtf.format(txDt);
+		this.calendarSystemIui = ISO_IUI;
 	}
 	
 	public String toString() {
@@ -59,6 +111,10 @@ public class TemporalReference extends ParticularReference {
 	}
 	
 	public boolean isIso() {
-		return isIso;
+		return this.calendarSystemIui.equals(ISO_IUI);
+	}
+
+	public Iui getCalendarSystemIui() {
+		return this.calendarSystemIui;
 	}
 }

--- a/src/main/java/edu/uams/dbmi/rts/time/TemporalRegion.java
+++ b/src/main/java/edu/uams/dbmi/rts/time/TemporalRegion.java
@@ -47,46 +47,31 @@ import edu.uams.dbmi.util.iso8601.TimeUnit;
  * 
  * 
  */
-public class TemporalRegion extends RtsDeclaration {
+public class TemporalRegion extends TemporalReference {
 
 
-	Iui calendarSystemIui;
 	Uui type;
-	TemporalReference tr;
 	
 	public static Uui ZERO_D_REGION_TYPE = new Uui("http://purl.obolibrary.org/obo/BFO_0000148");
 	public static Uui ONE_D_REGION_TYPE = new Uui("http://purl.obolibrary.org/obo/BFO_0000038");
 	
 	public static final TemporalRegion MAX_TEMPORAL_REGION;
-	
-	public static final Iui ISO_IUI;
-	public static final Iui RTS_TR_IUI;
-	
+
 	static {
-		ISO_IUI = Iui.createFromString("D4AF5C9A-47BA-4BF4-9BAE-F13A8ED6455E");
-		RTS_TR_IUI =  Iui.createFromString("DB2282A4-631F-4D2C-940F-A220C496F6BE");
-		MAX_TEMPORAL_REGION = new TemporalRegion(
-					UUID.fromString("26F1052B-311D-43B1-9ABC-B4E2EDD1B283"), 
-						TemporalRegion.ONE_D_REGION_TYPE);
+				MAX_TEMPORAL_REGION = new TemporalRegion(
+					"26F1052B-311D-43B1-9ABC-B4E2EDD1B283", 
+						RTS_TR_IUI, TemporalRegion.ONE_D_REGION_TYPE);
 	}
-	
-	
-	public TemporalRegion(TemporalReference tr, Uui type, Iui namingSystemIui) {
-		this.tr = tr;
-		if (tr.isIso && !namingSystemIui.equals(ISO_IUI))
-			throw new IllegalArgumentException("If temporal reference isIso, then calendar system iui must be" +
-					"the Iui for Gregorian calendar: " + ISO_IUI.toString());
-		if (!tr.isIso && namingSystemIui.equals(ISO_IUI))
-			throw new IllegalArgumentException("If temporal reference not isIso, then calendar system iui cannot be" +
-					"the Iui for Gregorian calendar: " + ISO_IUI.toString());
-		if (namingSystemIui == null) {
-			throw new IllegalArgumentException("calendar system IUI cannot be null: " + namingSystemIui);
-		}
-		this.calendarSystemIui = namingSystemIui;
+
+	public TemporalRegion(String identifier, Iui calendarSystemIui, Uui type) {
+		super(identifier, calendarSystemIui);
 		this.type = type;
 	}
 	
 	public TemporalRegion(Iso8601DateTime dateTime) {
+		super(dateTime);
+		this.type = ONE_D_REGION_TYPE;
+		/*
 		//regardless of whether time zone is specified, when we ask
 		//  the date/time object for a Calendar object, it comes 
 		//  with one (if not specified, it's the local one).
@@ -99,8 +84,9 @@ public class TemporalRegion extends RtsDeclaration {
 		
 		tr = new TemporalReference(dtf.format(dtZ), true);
 		calendarSystemIui = ISO_IUI;
+		*/
 		Iso8601Time t = dateTime.getTime();
-		type = ONE_D_REGION_TYPE;
+		this.type = ONE_D_REGION_TYPE;
 		if (t instanceof Iso8601UnitTime) {
 			Iso8601UnitTime ut = (Iso8601UnitTime)t;
 			if (ut.getUnit().equals(TimeUnit.MILLISECOND) || 
@@ -111,6 +97,9 @@ public class TemporalRegion extends RtsDeclaration {
 	}
 	
 	public TemporalRegion(Iso8601DateTime dateTime, TimeZone tz) {
+		super(dateTime, tz);
+		this.type = ONE_D_REGION_TYPE;
+		/*
 		//if the time zone is already specified, then illegal argument exception
 		if (dateTime.getTime().isTimeZoneSpecified()) {
 			throw new IllegalArgumentException("the DateTime object already has a time zone specified.");
@@ -134,7 +123,7 @@ public class TemporalRegion extends RtsDeclaration {
 		 *  	from the calendar, and format it!
 		 *  
 		 */
-		
+		/*
 		//gets a copy so we can change it without affecting the date/time object
 		GregorianCalendar c = (GregorianCalendar) dateTime.getCalendar(); 
 		//opposite of offset because we're converting from local to UTC, not 
@@ -147,7 +136,8 @@ public class TemporalRegion extends RtsDeclaration {
 				
 		calendarSystemIui = ISO_IUI;
 		//System.out.println(calendarSystemIui);
-		type = ONE_D_REGION_TYPE;
+		*/
+		this.type = ONE_D_REGION_TYPE;
 		Iso8601Time t = dateTime.getTime();
 		if (t instanceof Iso8601UnitTime) {
 			Iso8601UnitTime ut = (Iso8601UnitTime)t;
@@ -172,36 +162,19 @@ public class TemporalRegion extends RtsDeclaration {
 		// So leaning towards #2, where IUI has the status of something higher than just a 
 		// mere UUID.
 		
-		tr = new TemporalReference(UUID.randomUUID().toString(), false);
+		super(UUID.randomUUID().toString(), RTS_TR_IUI);
 		//DB2282A4-631F-4D2C-940F-A220C496F6BE refers to general RTS temporal reference
-		calendarSystemIui = RTS_TR_IUI;
 		this.type = type;
 	}
 	
-
 	public TemporalRegion(UUID id, Uui type) {
-		tr = new TemporalReference(UUID.randomUUID().toString(), false);
+		super(UUID.randomUUID().toString(), RTS_TR_IUI);
 		this.type = type;
-		calendarSystemIui = RTS_TR_IUI;
 	}
 
-	
 	public TemporalRegion(Iso8601Date db, TimeZone tz) {
-		tr = new TemporalReference(db, tz);
+		super(db, tz);
 		this.type = ONE_D_REGION_TYPE;
-		this.calendarSystemIui = ISO_IUI;
-	}
-
-	public TemporalReference getTemporalReference() {
-		return tr;
-	}
-	
-	public boolean isISO() {
-		return tr.isIso();
-	}
-	
-	public Iui getCalendarSystemIui() {
-		return calendarSystemIui;
 	}
 	
 	public Uui getTemporalType() {

--- a/src/main/java/edu/uams/dbmi/rts/tuple/RtsTuple.java
+++ b/src/main/java/edu/uams/dbmi/rts/tuple/RtsTuple.java
@@ -14,7 +14,7 @@ import edu.uams.dbmi.rts.tuple.component.IuiComponent;
  * @author Josh Hanna
  *
  */
-public abstract class RtsTuple extends RtsDeclaration {
+public abstract class RtsTuple implements RtsDeclaration {
 	
 	/*
 	 * IuiComponent contains IUI of Tuple itself

--- a/src/main/java/edu/ufl/ctsi/rts/text/RtsTupleTextWriter.java
+++ b/src/main/java/edu/ufl/ctsi/rts/text/RtsTupleTextWriter.java
@@ -128,7 +128,7 @@ public class RtsTupleTextWriter {
 		w.write(FIELD_DELIM);
 		w.write(rttc.getConceptCui().toString());
 		w.write(FIELD_DELIM);
-		w.write(rttc.getTemporalReference().toString());
+		w.write(rttc.toString());
 
 	}
 
@@ -161,7 +161,7 @@ public class RtsTupleTextWriter {
 		w.write(FIELD_DELIM);
 		w.write(rttl.getUniversalOntologyIui().toString());
 		w.write(FIELD_DELIM);
-		w.write(rttl.getTemporalReference().toString());
+		w.write(rttl.toString());
 	}
 
 	private void writePtoPTuple(RtsTuple rtt) throws IOException {
@@ -196,7 +196,7 @@ public class RtsTupleTextWriter {
 			if (iuis.hasNext()) w.write(SUBFIELD_DELIM);
 		}
 		w.write(FIELD_DELIM);
-		w.write(rttp.getTemporalReference().toString());
+		w.write(rttp.toString());
 	}
 
 	private void writePtoUTuple(RtsTuple rtt) throws IOException {
@@ -224,7 +224,7 @@ public class RtsTupleTextWriter {
 		w.write(FIELD_DELIM);
 		w.write(rttu.getUniversalOntologyIui().toString());
 		w.write(FIELD_DELIM);
-		w.write(rttu.getTemporalReference().toString());
+		w.write(rttu.toString());
 	}
 
 	private void writePtoDETuple(RtsTuple rtt) throws IOException {
@@ -284,15 +284,15 @@ public class RtsTupleTextWriter {
 	
 	public void writeTemporalRegion(TemporalRegion tr) throws IOException {
 		if (tr.getCalendarSystemIui() == null) {
-			System.err.println(tr.getTemporalReference().toString() + "\t" +
-					tr.getTemporalReference().isIso());
+			System.err.println(tr.toString() + "\t" +
+					tr.isIso());
 		}
 		w.write("T");
 		w.write(BLOCK_DELIM);
-		w.write(tr.getTemporalReference().toString());
+		w.write(tr.toString());
 		w.write(FIELD_DELIM);
 		w.write('<');
-		w.write(tr.getTemporalType().toString());
+		w.write(tr.toString());
 		w.write('>');
 		w.write(FIELD_DELIM);
 		w.write(tr.getCalendarSystemIui().toString());


### PR DESCRIPTION
…latter a subclass of the former. Required converting RtsDeclaration to an interface, which was easy because it is empty at the moment.