### PR TITLE
Changed equals method to properly compare Cui strings

### DIFF
--- a/src/main/java/edu/uams/dbmi/rts/cui/Cui.java
+++ b/src/main/java/edu/uams/dbmi/rts/cui/Cui.java
@@ -18,7 +18,7 @@ public class Cui {
 	public boolean equals(Object o){
 		if(o instanceof Cui){
 			Cui cui = (Cui) o;
-			return this.cui.equals(cui);
+			return this.cui.equals(cui.toString());
 		} else {
 			return false;
 		}


### PR DESCRIPTION
The previous Cui equals method always returned false, because it was calling a String's equals method on a non-String. This was changed to have the instance variable string of this.cui call equals on the toString output of the other Cui object. 